### PR TITLE
Fix recipe for chafa

### DIFF
--- a/recipes/chafa/build.sh
+++ b/recipes/chafa/build.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 # By installing from a release tar-ball (see meta.yaml), we avoid the
 # need for ./autogen.sh and additional dependencies
 
+export PKG_CONFIG_PATH="${BUILD_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+
 ./configure \
     --disable-debug \
     --disable-dependency-tracking \

--- a/recipes/chafa/meta.yaml
+++ b/recipes/chafa/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "chafa" %}
-{% set version = "1.14.0" %}
+{% set version = "1.14.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/hpjansson/{{ name }}/releases/download/{{ version }}/chafa-{{ version }}.tar.xz
-  sha256: 670e55c28b5ecd4c8187bd97f0898762712a480ec8ea439dae4a4836b178e084
+  sha256: 7b5b384d5fb76a641d00af0626ed2115fb255ea371d9bef11f8500286a7b09e5
 
 build:
   number: 0
@@ -19,21 +19,32 @@ requirements:
     - {{ stdlib('c') }}
     - pkg-config
     - make
-    - freetype
   host:
     - freetype
+    - cairo
     - glib
     - libjpeg-turbo
     - librsvg
     - libtiff
     - libwebp
+    - libpng
+    - libavif
+    - libjxl
+    - zlib
   run:
     - freetype
+    - cairo
     - glib
     - libjpeg-turbo
     - librsvg
     - libtiff
     - libwebp
+    - libpng
+    - libavif
+    - libjxl
+    - zlib
+    - gdk-pixbuf  # [osx]
+    - gettext  # [osx]
 
 test:
   commands:

--- a/recipes/chafa/meta.yaml
+++ b/recipes/chafa/meta.yaml
@@ -31,6 +31,8 @@ requirements:
     - libavif
     - libjxl
     - zlib
+    - gdk-pixbuf  # [osx]
+    - gettext  # [osx]
   run:
     - freetype
     - cairo

--- a/recipes/chafa/meta.yaml
+++ b/recipes/chafa/meta.yaml
@@ -27,10 +27,10 @@ requirements:
     - librsvg
     - libtiff
     - libwebp
-    - libpng
     - libavif
     - libjxl
-    - zlib
+    - libpng  # [linux]
+    - zlib  # [linux]
     - gdk-pixbuf  # [osx]
     - gettext  # [osx]
   run:
@@ -41,10 +41,10 @@ requirements:
     - librsvg
     - libtiff
     - libwebp
-    - libpng
     - libavif
     - libjxl
-    - zlib
+    - libpng  # [linux]
+    - zlib  # [linux]
     - gdk-pixbuf  # [osx]
     - gettext  # [osx]
 


### PR DESCRIPTION
The followings are the reasons for the error in the CI check.

- Misconfiguration of `PKG_CONFIG_PATH`
- zlib is missing at building time

I also added some packages by referring to the homebrew's [formula](https://github.com/Homebrew/homebrew-core/blob/f5e8c5cd0b52d6e1f49a3f215acd894bf048d0c0/Formula/c/chafa.rb).

I have confirmed that the build passed the local conda-build on linux x86_64, and the built package worked correctly when installed using `conda install`.